### PR TITLE
Close go language chooser

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -32,6 +32,8 @@ if err != nil {
 ctx.Export("kubeconfig", pulumi.ToSecret(myKube.Kubeconfig))
 ```
 
+{{% /choosable %}}
+
 {{% choosable language python %}}
 
 ```python


### PR DESCRIPTION
Adding a closing to tag to the go code in the language chooser.

see: https://github.com/pulumi/registry/pull/3153