### PR TITLE
Fix a broken link to the migragion guide

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -10,7 +10,7 @@ The `OVH` provider must be configured with credentials to deploy and update reso
 ## Information
 
 Note that the [lbrlabs Pulumi OVH provider](https://github.com/lbrlabs/pulumi-ovh) is replaced by this official one. See the
-[Migration Guide](./how-to-guides/migration-from-lbrlabs-package.md) for more information.
+[Migration Guide](https://github.com/ovh/pulumi-ovh/blob/main/docs/how-to-guides/migration-from-lbrlabs-package.md) for more information.
 
 ## Example
 


### PR DESCRIPTION
The link we have now points to a page that doesn't exist. This updates the link to point to the doc here in the repository, as we don't yet have support for third-party how-to guides. (That's tracked generally in https://github.com/pulumi/registry/issues/3391.)