### PR TITLE
feat: 🎉 Java SDK generation activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ tfgen:: install_plugins
 provider:: tfgen install_plugins # build the provider binary
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
-build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet #build_java # build all the sdks
+build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet build_java # build all the sdks
 
 build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs:: install_plugins tfgen # build the node sdk


### PR DESCRIPTION
This PR is to configure the OVHcloud's Pulumi provider to generate the Java SDK.  
Several steps must be done, all of these steps will be indicated in this PR.

 - [x] ⏳ Update makefile to generate the Java SDK and publish it
 - [x] ⏭️ Add App example
 - [x] ⏭️ Update CI to add automation to the Java SDK generation