### PR TITLE
Set `tfbridge.ProviderInfo.Version`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -145,6 +145,7 @@ func Provider() tfbridge.ProviderInfo {
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.
 		GitHubOrg: "ovh",
+		Version:   version.Version,
 		Config: map[string]*tfbridge.SchemaInfo{
 			"endpoint": {
 				Default: &tfbridge.DefaultInfo{


### PR DESCRIPTION
This PR sets `tfbridge.ProviderInfo.Version`. 

This should avoid errors like:
![image_720](https://github.com/ovh/pulumi-ovh/assets/22222529/9695bd80-a8d6-4bed-8b59-8bed958231ef)

