### PR TITLE
Refactor: Common cleanup from Pulumi's bridge template

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -145,6 +145,7 @@ func Provider() tfbridge.ProviderInfo {
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.
 		GitHubOrg: "ovh",
+		Version:   version.Version,
 		Config: map[string]*tfbridge.SchemaInfo{
 			"endpoint": {
 				Default: &tfbridge.DefaultInfo{


### PR DESCRIPTION
This PR refactors the `resources.go` file by using several tfbridge builtins instead of
custom functions. It also replaces `"path/filepath"` with `"path"`, since we don't want
platform specific behavior for the go path. It removes any reference to
`PreConfigureCallback`, since that hook is not used.

This PR is stacked on top of #107.