### PR TITLE
Upgrade terraform-provider-ovh to v2.11.0

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.10
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/ovh/terraform-provider-ovh/v2 v2.10.0
+	github.com/ovh/terraform-provider-ovh/v2 v2.11.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.112.0
 	github.com/pulumi/pulumi/sdk/v3 v3.185.0
 )
@@ -132,6 +132,7 @@ require (
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/ovh/go-ovh v1.7.0 // indirect
+	github.com/peterhellberg/duration v0.0.2 // indirect
 	github.com/pgavlin/fx v0.1.6 // indirect
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2141,6 +2141,10 @@ github.com/ovh/terraform-provider-ovh/v2 v2.9.0 h1:hzXQKcnbrKAF2r1SpE4S/ObA6ivLn
 github.com/ovh/terraform-provider-ovh/v2 v2.9.0/go.mod h1:F7BBts710Seiv28R21bpYlSk6XjIHp2EVQzFmtmb2Zo=
 github.com/ovh/terraform-provider-ovh/v2 v2.10.0 h1:gV6WdeEMZwHO/Ceu306mv4zFG1rw0e4aPFwuusclhq4=
 github.com/ovh/terraform-provider-ovh/v2 v2.10.0/go.mod h1:tpUCaMqmSIVvTWRFpOo7Ux2rbHVnLCltgFE6h/teHX4=
+github.com/ovh/terraform-provider-ovh/v2 v2.11.0 h1:gzmvNCJ/jnes3LXE5O/6oCjpNHqBfGHa9gCWlj/cUF4=
+github.com/ovh/terraform-provider-ovh/v2 v2.11.0/go.mod h1:bsLchS5uERurzoxfCW3YZxDMblvYKxWu9hj7BDUf2JQ=
+github.com/peterhellberg/duration v0.0.2 h1:J/ELSSpXCuHInfYJ/hGVYe0enoGsD8buoRzbsdQJW5o=
+github.com/peterhellberg/duration v0.0.2/go.mod h1:n3Pkw/vId7ZwR2ITRQlLeIjETlGEtUa7zQw49dED6ew=
 github.com/pgavlin/fx v0.1.6 h1:r9jEg69DhNoCd3Xh0+5mIbdbS3PqWrVWujkY76MFRTU=
 github.com/pgavlin/fx v0.1.6/go.mod h1:KWZJ6fqBBSh8GxHYqwYCf3rYE7Gp2p0N8tJp8xv9u9M=
 github.com/pgavlin/fx/v2 v2.0.3 h1:ZBVklTFjxcWvBVPE+ti5qwnmTIQ0Gq6nuj3J5RKDtKk=


### PR DESCRIPTION
This PR was generated via GH action
- Upgrading terraform-provider-ovh to v2.11.0.