### PR TITLE
`ovh.Dedicated.Server` cannot be created through Pulumi

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -320,7 +320,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_dedicated_server": {
 				Tok:       ovhResource(dedicatedMod, "Server"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 			"ovh_dedicated_server_reinstall_task": {
 				Tok: ovhResource(dedicatedMod, "ServerReinstallTask"),
@@ -356,11 +356,11 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_domain_zone_dnssec": {
 				Tok:       ovhResource(domainMod, "ZoneDNSSec"),
-				ComputeID: delegateID("zone_name"),
+				ComputeID: delegateID("zoneName"),
 			},
 			"ovh_domain_zone_import": {
 				Tok:       ovhResource(domainMod, "ZoneImport"),
-				ComputeID: delegateID("zone_name"),
+				ComputeID: delegateID("zoneName"),
 			},
 			"ovh_domain_zone_dynhost_login": {
 				Tok: ovhResource(domainMod, "DynhostLogin"),
@@ -452,7 +452,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_iploadbalancing_ssl": {
 				Tok:       ovhResource(ipLoadBalancingMod, "Ssl"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 			"ovh_iploadbalancing_tcp_farm": {
 				Tok: ovhResource(ipLoadBalancingMod, "TcpFarm"),
@@ -471,15 +471,15 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_iploadbalancing_udp_farm": {
 				Tok:       ovhResource(ipLoadBalancingMod, "UdpFarm"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 			"ovh_iploadbalancing_udp_farm_server": {
 				Tok:       ovhResource(ipLoadBalancingMod, "UdpFarmServer"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 			"ovh_iploadbalancing_udp_frontend": {
 				Tok:       ovhResource(ipLoadBalancingMod, "UdpFrontend"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 			"ovh_iploadbalancing_vrack_network": {
 				Tok: ovhResource(ipLoadBalancingMod, "VrackNetwork"),
@@ -533,7 +533,7 @@ func Provider() tfbridge.ProviderInfo {
 				// VrackDedicatedCloud instead of DedicatedCloud fix until we don't have to create a ComputeID
 				// based on a dedicated_cloud field (error in dotnet sdk generation)
 				Tok:       ovhResource(vrackMod, "VrackDedicatedCloud"),
-				ComputeID: delegateID("dedicated_cloud"),
+				ComputeID: delegateID("dedicatedCloud"),
 			},
 			"ovh_vrack_dedicated_cloud_datacenter": {
 				Tok:       ovhResource(vrackMod, "DedicatedCloudDatacenter"),
@@ -561,7 +561,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_vrack_ovhcloudconnect": {
 				Tok:       ovhResource(vrackMod, "OVHcloudConnect"),
-				ComputeID: delegateID("ovh_cloud_connect"),
+				ComputeID: delegateID("ovhCloudConnect"),
 			},
 			"ovh_vrack_vrackservices": {
 				// "Vrackservices" Mandatory name to avoid CSharp issue: member names cannot be the same as their enclosing type
@@ -604,7 +604,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"ovh_vps": {
 				Tok:       ovhResource(vpsMod, "Vps"),
-				ComputeID: delegateID("display_name"),
+				ComputeID: delegateID("displayName"),
 			},
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{


### PR DESCRIPTION
I was unable to use the create on a dedicated server due to an error:
`Could not find required property 'display_name' in state`. 
 
Which seems to be the same as this:  [Issue #306](https://github.com/ovh/pulumi-ovh/issues/306).

The provisioning seemed to work, the server is now running the operating system I was attempting to provision, but pulumi failed to compute an ID and did not persist the state. 

The following was written and explored with the help of claude code, so please take all of it with a grain of salt. My intent is not to create more work, and hopefully this change is small enough to be easy to review. I have read the contributing guidelines and code of conduct, but I don't have the appropriate development environment setup. If that's all that's standing in the way of getting this merged, then I am happy to spend some time to get that working and go through more of it.

## Summary of the changes:

I believe that it stems from the translation of names between layers. For example, the OVH API calls this field `displayName`. Terraform renames it to `display_name`. The Pulumi bridge renames it back to `displayName`. `pulumi-ovh` looks it up as `display_name`, which is the Terraform spelling, in a map that uses the Pulumi one.

Even if this rename is correct, there is a further potential bug that should be considered, which is that it does not appear that displayName is required and it can be null / undefined.  Perhaps a better ID would be based on `serviceName`, but I don't know this code base, or the OVH API well enough to be certain about this. 

## Some evidence:

1. **The API spells it `displayName`, and the server endpoint does not return it.** [`ca.api.ovh.com/1.0/dedicated/server.json`](https://ca.api.ovh.com/1.0/dedicated/server.json) defines no `displayName` on any model. A live `GET /dedicated/server/{serviceName}` returns it only nested, as `iam.displayName`. [PR #1201](https://github.com/ovh/terraform-provider-ovh/pull/1201) says so outright, *"the `display_name` value is not part of the `GET /dedicated/server/` response"*, and copies the nested value across. That shipped in v2.11.0 on 2026-01-28. Before it, the field was absent from read state entirely.

2. **Terraform converts it to `display_name`.** The struct tags are the conversion: `json` marshals to and from the API, `tfsdk` to and from Terraform state and HCL, on the one struct field: [`resource_dedicated_server_gen.go`](https://github.com/ovh/terraform-provider-ovh/blob/v2.17.0/ovh/resource_dedicated_server_gen.go#L718).

3. **The Pulumi bridge converts it back to `displayName`.** [`names.go`](https://github.com/pulumi/pulumi-terraform-bridge/blob/v3.112.0/pkg/tfbridge/names.go#L63-L67), *"performs a standard transformation on the given name string, from Terraform's underscore_casing to Pulumi's camelCasing"*. `ComputeID` receives the output of `ToPropertyMap`, so its keys are Pulumi names.

4. **`pulumi-ovh` asks for the Terraform spelling.** `ovh_dedicated_server` sets `ComputeID: delegateID("display_name")`: [`provider/resources.go`](https://github.com/ovh/pulumi-ovh/blob/master/provider/resources.go#L321-L323). `delegateID` forwards to `DelegateIDField(field resource.PropertyKey, ...)`, whose parameter is named `pulumiField`, and which looks the key up directly and converts nothing.

Changing it to `delegateID("displayName")`, rebuilding locally and doing some local filesystem fiddling to make it use my version resulted in a successful pulumi call.

I've included a bulk rename, although I have not tested any of the rest of them either. I would be very happy to perform more testing, but I'm not yet familiar enough with the code base to do this confidently and I'm not about to believe claude code when it tells me it's going to work.   However,  `make schema` generates  `provider/cmd/pulumi-resource-ovh/schema.json`, which seems to have all of these fields named with `camelCase`, so I think it might be correct. 